### PR TITLE
Update identifier indices for inline examples

### DIFF
--- a/input/fsh/exampleProductBundles/seCefuroximeStragen1.5gPowder.fsh
+++ b/input/fsh/exampleProductBundles/seCefuroximeStragen1.5gPowder.fsh
@@ -46,8 +46,8 @@ InstanceOf: PPLMedicinalProductDefinition
 Usage: #inline
 
 * identifier[mpid].value = "SE-100002835-00050006"
-* identifier[+].system = "http://ema.europa.eu/fhir/eurdId"
-* identifier[=].value = "615"
+* identifier[1].system = "http://ema.europa.eu/fhir/eurdId"
+* identifier[1].value = "615"
 * domain = $100000000004#100000000012 "Human use"
 * status = $200000005003#200000005004 "Current"
 * combinedPharmaceuticalDoseForm = $200000000004#100000116186 "Powder for solution for injection/infusion"

--- a/input/fsh/exampleProductBundles/sePanodil500mgPowderInSachet.fsh
+++ b/input/fsh/exampleProductBundles/sePanodil500mgPowderInSachet.fsh
@@ -45,8 +45,8 @@ InstanceOf: PPLMedicinalProductDefinition
 Usage: #inline
 
 * identifier[mpid].value = "SE-100004600-00012391"
-* identifier[+].system = "http://ema.europa.eu/fhir/eurdId"
-* identifier[=].value = "2283"
+* identifier[1].system = "http://ema.europa.eu/fhir/eurdId"
+* identifier[1].value = "2283"
 * domain = $100000000004#100000000012 "Human use"
 * status = $200000005003#200000005004 "Current"
 * combinedPharmaceuticalDoseForm = $200000000007#100000125752 "Powder for oral solution in sachet"


### PR DESCRIPTION
While testing [a planned feature for SUSHI v3.0](https://github.com/FHIR/sushi/pull/1261), I discovered a potential discrepancy involving the use of soft indexing in two examples. If my understanding of the intent of these examples is correct, the `identifier` arrays should have two elements in them: the named `mpid` slice, followed by an element without a slice name.

SUSHI currently resolves soft indexing in a way that does not account for existing named slices. As a result, the identifier slices on these examples were having the values in the `mpid` slice overwritten. This update sets the indices such that there are two elements in the identifier arrays. The manual slice ordering feature that will be part of SUSHI v3.0 will allow soft indexing to be used here, if the feature is enabled.